### PR TITLE
added modifiable b_0 fitting for applying z-reion

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Contributors
 ============
 
 * Paul La Plante <plaplant@berkeley.edu>
+* Hugo Baraer <hugo.baraer@mail.mcgill.ca>

--- a/src/zreion/zreion.py
+++ b/src/zreion/zreion.py
@@ -157,7 +157,7 @@ def _fft3d(array, data_shape, direction="f"):
 def apply_zreion(
     density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0=1.0 / 1.686
 ):
-    """
+    r"""
     Apply zreion ionization history to density field.
 
     Parameters
@@ -182,8 +182,9 @@ def apply_zreion(
     deconvolve : bool, optional
         Whether to deconvolve the CIC particle deposition window. If density
         grid is derived in Eulerian space directly, this step is not needed.
-    b_0 : float, optional
-        Default = 0.593, the b_0 value of the bias parameter (if fitting for)
+    b0 : float, optional
+        The b_0 value of the bias parameter. Defaults to 1 / \delta_c.
+
     Returns
     -------
     zreion : numpy array
@@ -269,7 +270,7 @@ def apply_zreion(
 def apply_zreion_fast(
     density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0=1.0 / 1.686
 ):
-    """
+    r"""
     Use as a fast, drop-in replacement for apply_zreion.
 
     The speedups are accomplished by using pyfftw for FFT computation, and
@@ -298,8 +299,8 @@ def apply_zreion_fast(
     deconvolve : bool, optional
         Whether to deconvolve the CIC particle deposition window. If density
         grid is derived in Eulerian space directly, this step is not needed.
-    b_0 : float, optional
-        Default = 0.593, the b_0 value of the bias parameter (if fitting for)
+    b0 : float, optional
+        The b_0 value of the bias parameter. Defaults to 1 / \delta_c.
 
     Returns
     -------

--- a/src/zreion/zreion.py
+++ b/src/zreion/zreion.py
@@ -10,6 +10,7 @@ import pyfftw
 
 from . import _zreion
 
+
 def tophat(x):
     """
     Compute spherical tophat Fourier window function.
@@ -153,7 +154,9 @@ def _fft3d(array, data_shape, direction="f"):
     return fftw_obj()
 
 
-def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True,  b0 = 1.0 / 1.686):
+def apply_zreion(
+    density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0=1.0 / 1.686
+):
     """
     Apply zreion ionization history to density field.
 
@@ -263,7 +266,9 @@ def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=Tru
     return zreion
 
 
-def apply_zreion_fast(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0 = 1.0 / 1.686):
+def apply_zreion_fast(
+    density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0=1.0 / 1.686
+):
     """
     Use as a fast, drop-in replacement for apply_zreion.
 

--- a/src/zreion/zreion.py
+++ b/src/zreion/zreion.py
@@ -10,10 +10,6 @@ import pyfftw
 
 from . import _zreion
 
-# define constants
-b0 = 1.0 / 1.686
-
-
 def tophat(x):
     """
     Compute spherical tophat Fourier window function.
@@ -157,7 +153,7 @@ def _fft3d(array, data_shape, direction="f"):
     return fftw_obj()
 
 
-def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True):
+def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True,  b0 = 1.0 / 1.686):
     """
     Apply zreion ionization history to density field.
 
@@ -183,7 +179,8 @@ def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=Tru
     deconvolve : bool, optional
         Whether to deconvolve the CIC particle deposition window. If density
         grid is derived in Eulerian space directly, this step is not needed.
-
+    b_0 : float, optional
+        Default = 0.593, the b_0 value of the bias parameter (if fitting for)
     Returns
     -------
     zreion : numpy array
@@ -266,7 +263,7 @@ def apply_zreion(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=Tru
     return zreion
 
 
-def apply_zreion_fast(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True):
+def apply_zreion_fast(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolve=True, b0 = 1.0 / 1.686):
     """
     Use as a fast, drop-in replacement for apply_zreion.
 
@@ -296,6 +293,8 @@ def apply_zreion_fast(density, zmean, alpha, k0, boxsize, rsmooth=1.0, deconvolv
     deconvolve : bool, optional
         Whether to deconvolve the CIC particle deposition window. If density
         grid is derived in Eulerian space directly, this step is not needed.
+    b_0 : float, optional
+        Default = 0.593, the b_0 value of the bias parameter (if fitting for)
 
     Returns
     -------


### PR DESCRIPTION
The option to add b_0 parameter as free parameter was used in the apply_zreion and the apply z_reion_fast function to allow the use of externally fitted b_0.