### PR TITLE
Fix warnings in tests

### DIFF
--- a/tests/test_zreion.py
+++ b/tests/test_zreion.py
@@ -61,7 +61,7 @@ def fake_data_random_anisotropic():
 
 
 # define cases decorator
-fake_data_cases = pytest_cases.parametrize_plus(
+fake_data_cases = pytest_cases.parametrize(
     "fake_data",
     [
         pytest_cases.fixture_ref(fake_data_deterministic),


### PR DESCRIPTION
This PR renames `parameterize_plus` -> `parametrize` as part of `pytest_cases`. Doing so removes a warning when running tests.