### PR TITLE
Add GitHub action to build wheels

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Package
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[testing]
+        pip install -e .[test]
     - name: Run tests using pytest
       run: |
         pytest --cov-report xml:./coverage.xml

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.8.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_TEST_REQUIRES: packaging pytest pytest-cov pytest-cases
+          CIBW_TEST_COMMAND: "python -m pytest {package}/tests"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: atrifact
           path: dist
-      - uses: pypa@gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,23 +4,30 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        buildplat:
+          - [ubuntu-20.04, manylinux_x86_64]
+          - [macos-10.15, macosx_*]
+          - [windows-2019, win_amd64]
+          - [windows-2019, win32]
+        python:
+          - ["cp37", "cp38", "cp39", "cp310"]
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.8.1
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.8.1
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - uses: actions/upload-artifact@v3
         with:
+          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.8.1
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_TEST_REQUIRES: packaging pytest pytest-cov pytest-cases
           CIBW_TEST_COMMAND: "python -m pytest {package}/tests"
+          CIBW_TEST_SKIP: "*-win32"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v3
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build wheels
 
 on: [push, pull_request]
 
@@ -14,8 +14,7 @@ jobs:
           - [macos-10.15, macosx_*]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
-        python:
-          - ["cp37", "cp38", "cp39", "cp310"]
+        python: ["cp37", "cp38", "cp39", "cp310"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,3 +32,30 @@ jobs:
         with:
           name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: atrifact
+          path: dist
+      - uses: pypa@gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,12 @@
 name = zreion
 description = A python-based method for generating cosmological reionization fields
 author = Paul La Plante
-author-email = plaplant@berkeley.edu
+author_email = paul.laplante@unlv.edu
 license = mit
-long-description = file: README.md
-long-description-content-type = text/x-md; charset=UTF-8
+long_description = file: README.md
+long_description_content_type = text/x-md; charset=UTF-8
 url = https://github.com/plaplant/zreion
-project-urls =
+project_urls =
     Documentation = https://github.com/plaplant/zreion
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,9 @@ author-email = plaplant@berkeley.edu
 license = mit
 long-description = file: README.md
 long-description-content-type = text/x-md; charset=UTF-8
-url = https://github.com/pyscaffold/pyscaffold/
+url = https://github.com/plaplant/zreion
 project-urls =
-    Documentation = https://pyscaffold.org/
+    Documentation = https://github.com/plaplant/zreion
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any
 # Add here all kinds of additional classifiers as defined under
@@ -46,7 +46,7 @@ exclude =
 # `pip install zreion[PDF]` like:
 # PDF = ReportLab; RXP
 # Add here test requirements (semicolon/line-separated)
-testing =
+test =
     packaging
     pytest
     pytest-cov


### PR DESCRIPTION
Because we use cython, we need to build platform-specific wheels for uploading to PyPI. This uses cibuildwheel to handle this automatically, and upload to PyPI on a tagged release.