### PR TITLE
Change how artifacts are handled

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: atrifact
+          name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,6 +48,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: sdist
           path: dist/*.tar.gz
   upload_all:
     needs: [build_wheels, make_sdist]
@@ -56,7 +57,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-07-29
+
+### Added
+- Allow users to specify `b0` parameter in scale-dependent bias term.
+
 ## [0.1.0] - 2020-01-25
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-07-29
+
+### Fixed
+- Fixed GitHub action for PyPI upload.
+
 ## [0.2.0] - 2022-07-29
 
 ### Added


### PR DESCRIPTION
This PR changes how artifacts are handled in GitHub actions, in an attempt to make the actual upload to PyPI a success.