### PR TITLE
Fix PyPI upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - name: Move folders around
+        working-directory: dist
+        run: |
+          for dir in `ls .`; do
+            cd $dir
+            mv * ..
+            cd ..
+            rmdir $dir
+          done
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.5.0
         with:
-          user: __token__
           password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.2] - 2022-07-29
+
+### Fixed
+- Fixed PyPI upload yet again.
+
 ## [0.2.1] - 2022-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ top-level of the repo. In addition to the package dependencies, it requires
 `packaging`, `pytest-cov` and `pytest-cases`. These can be installed using:
 
 ```
-pip install .[testing]
+pip install .[test]
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ author = Paul La Plante
 author_email = paul.laplante@unlv.edu
 license = mit
 long_description = file: README.md
-long_description_content_type = text/x-md; charset=UTF-8
+long_description_content_type = text/markdown; charset=UTF-8
 url = https://github.com/plaplant/zreion
 project_urls =
     Documentation = https://github.com/plaplant/zreion


### PR DESCRIPTION
In the previous version, there was a problem with how GitHub artifacts were handled and unpacked prior to upload. This PR should fix those issues.